### PR TITLE
Fix default behavior in user class query

### DIFF
--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -28,7 +28,7 @@ router.get('/user_data', (req, res) => {
 router.get('/user_data/class', (req, res) => {
     if (req.user === undefined) {
         res.json({
-            a: 4,
+            a: null,
         });
     } else {
         res.json({


### PR DESCRIPTION
This is an enum now, so returning a number doesn't really make sense.