### PR TITLE
Fix schema.sql syntax for postgres <10

### DIFF
--- a/src/server/sql/schema.sql
+++ b/src/server/sql/schema.sql
@@ -65,7 +65,7 @@ CREATE TABLE ballots (
     updated_at timestamptz DEFAULT now()
 );
 
-DROP FUNCTION IF EXISTS set_score_submit_time;
+DROP FUNCTION IF EXISTS set_score_submit_time();
 CREATE FUNCTION set_score_submit_time()
 RETURNS TRIGGER AS $$
 BEGIN


### PR DESCRIPTION
We can only omit args here in Postgres 10+, which I'm not using, and it doesn't hurt to make this line compatible with older versions.
