### PR TITLE
Fix auto assign issue

### DIFF
--- a/client/src/components/admin/PageAdminProjectsEpicenter.tsx
+++ b/client/src/components/admin/PageAdminProjectsEpicenter.tsx
@@ -248,6 +248,7 @@ const PageAdminProjectsEpicenterComponent: React.FC<PageAdminProjectsEpicenterPr
       // pick a random judge
       const randomUserID = userIDs[Math.floor(Math.random() * userIDs.length)];
       console.log("Random judge", randomUserID);
+      let judgeCompany = props.users[randomUserID].company!
       // get projects that can be assigned to a judge
       const canAssignProjects = Object.values(state.projects).filter((project: Project) => {
         // check that project is in current expo & round
@@ -271,17 +272,18 @@ const PageAdminProjectsEpicenterComponent: React.FC<PageAdminProjectsEpicenterPr
         // sort projects by health
       }).sort((a: ProjectWithHealth, b: ProjectWithHealth) => {
         // return a.health - b.health;
-        let company = props.users[randomUserID].company!
-        return calculateProjectCompanyHealth(a, company) - calculateProjectCompanyHealth(b, company)
+        return calculateProjectCompanyHealth(a, judgeCompany) - calculateProjectCompanyHealth(b, judgeCompany)
       });
       console.log("Projects to be assigned", canAssignProjects);
-      
+
       if (canAssignProjects.length > 0) {
         // get lowest health value
-        const lowestHealth = canAssignProjects[0].health;
+        // const lowestHealth = canAssignProjects[0].health;
+        const lowestHealth = calculateProjectCompanyHealth(canAssignProjects[0], judgeCompany);
         // get projects with health = lowest health value
         const sameLowestHealthProjects = canAssignProjects.filter((project: ProjectWithHealth) => {
-          return project.health === lowestHealth;
+          // return project.health === lowestHealth;
+          return calculateProjectCompanyHealth(project, judgeCompany) === lowestHealth;
         });
 
         // randomly pick project to assign from among projects with health = lowest health value

--- a/client/src/components/admin/PageAdminProjectsEpicenter.tsx
+++ b/client/src/components/admin/PageAdminProjectsEpicenter.tsx
@@ -171,40 +171,55 @@ const PageAdminProjectsEpicenterComponent: React.FC<PageAdminProjectsEpicenterPr
 
   const calculateProjectHealth = (project: Project) => {
     let totalHealth = 0;
+
+    /* 
+    // This block checks the number of times a project has been judged for the default category
+
+    // If project has already been judged
     if (props.ballots.dProjectScores[project.id!] && Object.values(props.ballots.dProjectScores[project.id!]).length > 0) {
       const categoryScoreArrays: { [userID: number]: number } = {};
       const allUserBallots = Object.values(props.ballots.dProjectScores[project.id!]);
+      // The default prize category
       let defaultCategoryID = Object.values(props.categories.categories).filter((category: Category) => {
         return category.isDefault
       })[0].id;
       console.log('default', defaultCategoryID);
+      // Iterate over all ballots for project
       for (const userBallots of allUserBallots) {
+        // Get the ballot associated with that judgement
         for (const ballot of userBallots) {
+          // If the judge was for the default category (i.e. overall hackgt or how all judging is in healthtech)
           if (props.categories.criteria[ballot.criteriaID].categoryID === defaultCategoryID) {
+            // If the judge hasn't been put into the map
             if (!categoryScoreArrays[ballot.userID]) {
               categoryScoreArrays[ballot.userID] = 0;
             }
-
+            // Add the judge's id -> score into the map
             categoryScoreArrays[ballot.userID] += ballot.score;
           }
         }
       }
 
       console.log('calcProjectHe', categoryScoreArrays);
+      // Add the number of times the project has been judged
       totalHealth += Object.values(categoryScoreArrays).length;
     }
+    */
 
     for (const judgeQueue of Object.values(props.ballots.dJudgeQueues)) {
+      // If project is in the queue increase the health by 1
       if (judgeQueue.queuedProject && judgeQueue.queuedProject.id === project.id!) {
         totalHealth++;
       }
 
+      // If project is currently being judged increase health by 2
       if (judgeQueue.activeProjectID === project.id!) {
-        totalHealth++;
+        totalHealth += 2;
       }
 
+      // If judge already judged this project
       if (judgeQueue.otherProjectIDs.includes(project.id!)) {
-        totalHealth++;
+        totalHealth += 2;
       }
     }
 
@@ -227,12 +242,12 @@ const PageAdminProjectsEpicenterComponent: React.FC<PageAdminProjectsEpicenterPr
       }
       return judgingUsers;
     }, []);
-    console.log(userIDs);
+    console.log("User IDS", userIDs);
     // check that there is at least one judge that we can assign the project to
     if (userIDs.length > 0) {
       // pick a random judge
       const randomUserID = userIDs[Math.floor(Math.random() * userIDs.length)];
-      console.log(randomUserID);
+      console.log("Random judge", randomUserID);
       // get projects that can be assigned to a judge
       const canAssignProjects = Object.values(state.projects).filter((project: Project) => {
         // check that project is in current expo & round
@@ -257,7 +272,7 @@ const PageAdminProjectsEpicenterComponent: React.FC<PageAdminProjectsEpicenterPr
       }).sort((a: ProjectWithHealth, b: ProjectWithHealth) => {
         return a.health - b.health;
       });
-      console.log(canAssignProjects);
+      console.log("Projects to be assigned", canAssignProjects);
 
       if (canAssignProjects.length > 0) {
         // get lowest health value


### PR DESCRIPTION
Select projects not based off health, but based off company health. Company health is determined in the following way:
- Projects get a health score of +2 if they are currently being judged or if they have already been judged
- Projects get a health score+1 for if they are in a queue.

The project with the lowest company score is what is assigned to a judge of that company.